### PR TITLE
Added config options to Mana Liquefaction Device

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     moddesc = "A Botania Addon adds some new flowers and miscs."
 }
 group = "com.meteor.extrabotany"
-version = "r1.1-60"
+version = "r1.1-61"
 
 archivesBaseName = modname
 

--- a/src/main/java/com/meteor/extrabotany/common/core/config/ConfigHandler.java
+++ b/src/main/java/com/meteor/extrabotany/common/core/config/ConfigHandler.java
@@ -120,6 +120,17 @@ public class ConfigHandler {
 	public static boolean ENABLE_TRUEDAMAGE = true;
 	public static boolean ENABLE_ILLEGALACTION = false;
 
+	public static int INITIAL_LIQUEFACTION_ENERGY = 0;
+	public static int MAX_LIQUEFACTION_MANA = 1000000;
+	public static int LIQUEFACTION_STORAGE_DRAIN = 1;
+	public static int LIQUEFACTION_STORAGE_DRAIN_CONTAINER = 1;
+	public static int LIQUEFACTION_STORAGE_PUMP = 25;
+	public static int LIQUEFACTION_STORAGE_PUMP_CONTAINER = 25;
+	public static int LIQUEFACTION_MANA_RECEIVE = 2000;
+	public static int LIQUEFACTION_ENERGY_LOSS = 2;
+	public static int LIQUEFACTION_MANA_GIVE = 2000;
+	public static int LIQUEFACTION_ENERGY_GAIN = 2;
+
 	public void loadConfig(FMLPreInitializationEvent event) {
 		CONFIG = new Configuration(event.getSuggestedConfigurationFile());
 		CONFIG.load();
@@ -291,6 +302,28 @@ public class ConfigHandler {
 
 		EFF_GEMINIORCHID = CONFIG.getFloat("efficiency", "geminiorchid", 1F, 0, Integer.MAX_VALUE, "");
 		EFF_ELDELWEISS = CONFIG.getFloat("efficiency", "edelweiss", 1F, 0, Integer.MAX_VALUE, "");
+
+		INITIAL_LIQUEFACTION_ENERGY = CONFIG.getInt("How much mana the device contains upon creation. Default is 0", "mana liquefaction", 0, 0,
+				Integer.MAX_VALUE, "");
+		MAX_LIQUEFACTION_MANA = CONFIG.getInt("How much mana can the Mana Liquefaction Device store. Default is 1000000", "mana liquefaction", 1000000, 0,
+				Integer.MAX_VALUE, "");
+		LIQUEFACTION_STORAGE_DRAIN = CONFIG.getInt("How much mana the Mana Liquefaction Device drains from containers on update. Default is 1", "mana liquefaction", 1, 0,
+				Integer.MAX_VALUE, "");
+		LIQUEFACTION_STORAGE_DRAIN_CONTAINER = CONFIG.getInt("How much energy the Mana Liquefaction Device gets from \"one drain\". Default is 1", "mana liquefaction", 1, 0,
+				Integer.MAX_VALUE, "");
+		LIQUEFACTION_STORAGE_PUMP = CONFIG.getInt("How much mana the Mana Liquefaction Device pumps at a time into a container. Default is 25", "mana liquefaction", 25, 0,
+				Integer.MAX_VALUE, "");
+		LIQUEFACTION_STORAGE_PUMP_CONTAINER = CONFIG.getInt("How much a container gets mana from one transfer from Mana Liquefaction Device. Default is 25", "mana liquefaction", 25, 0,
+				Integer.MAX_VALUE, "");
+		LIQUEFACTION_MANA_RECEIVE = CONFIG.getInt("How much a Mana Liquefaction Device receives mana on update. Default is 2000", "mana liquefaction", 2000, 0,
+				Integer.MAX_VALUE, "");
+
+		LIQUEFACTION_ENERGY_LOSS = CONFIG.getInt("How much energy a Mana Liquefaction Device loses on update. Default is 2", "mana liquefaction", 2, 0,
+				Integer.MAX_VALUE, "");
+		LIQUEFACTION_MANA_GIVE = CONFIG.getInt("How much a Mana Liquefaction Device gives mana on update. Default is 2000", "mana liquefaction", 2000, 0,
+				Integer.MAX_VALUE, "");
+		LIQUEFACTION_ENERGY_GAIN = CONFIG.getInt("How much energy a Mana Liquefaction Device receives on update. Default is 2", "mana liquefaction", 2, 0,
+				Integer.MAX_VALUE, "");
 
 		if (CONFIG.hasChanged())
 			CONFIG.save();

--- a/src/main/java/com/meteor/extrabotany/common/item/relic/ItemDaedalusStormbow.java
+++ b/src/main/java/com/meteor/extrabotany/common/item/relic/ItemDaedalusStormbow.java
@@ -189,6 +189,7 @@ public class ItemDaedalusStormbow extends ItemBow implements IManaUsingItem, IRe
 		return angle + f;
 	}
 
+	/* does not compile when private, public works, did not investigate - jackowski626 */
 	private ItemStack findAmmo(EntityPlayer player) {
 		if (this.isArrow(player.getHeldItem(EnumHand.OFF_HAND))) {
 			return player.getHeldItem(EnumHand.OFF_HAND);

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "extrabotany",
   "name": "ExtraBotany",
   "description": "A Botania addon.",
-  "version": "r1.1-60",
+  "version": "r1.1-61",
   "mcversion": "1.12.2",
   "url": "",
   "updateUrl": "",


### PR DESCRIPTION
Gives people and pack-makers more control over the Liquefaction Device
`
"mana liquefaction" {
    #  [range: 0 ~ 2147483647, default: 2000]
    I:"How much a Mana Liquefaction Device gives mana on update. Default is 2000"=2000

    #  [range: 0 ~ 2147483647, default: 2000]
    I:"How much a Mana Liquefaction Device receives mana on update. Default is 2000"=2000

    #  [range: 0 ~ 2147483647, default: 25]
    I:"How much a container gets mana from one transfer from Mana Liquefaction Device. Default is 25"=25

    #  [range: 0 ~ 2147483647, default: 2]
    I:"How much energy a Mana Liquefaction Device loses on update. Default is 2"=2

    #  [range: 0 ~ 2147483647, default: 2]
    I:"How much energy a Mana Liquefaction Device receives on update. Default is 2"=2

    #  [range: 0 ~ 2147483647, default: 1]
    I:"How much energy the Mana Liquefaction Device gets from "one drain". Default is 1"=1

    #  [range: 0 ~ 2147483647, default: 1000000]
    I:"How much mana can the Mana Liquefaction Device store. Default is 1000000"=1000000

    #  [range: 0 ~ 2147483647, default: 1]
    I:"How much mana the Mana Liquefaction Device drains from containers on update. Default is 1"=1

    #  [range: 0 ~ 2147483647, default: 25]
    I:"How much mana the Mana Liquefaction Device pumps at a time into a container. Default is 25"=25

    #  [range: 0 ~ 2147483647, default: 0]
    I:"How much mana the device contains upon creation. Default is 0"=0
}
`